### PR TITLE
Feature / Add upload to local 

### DIFF
--- a/lib/crawley/local_storage.ex
+++ b/lib/crawley/local_storage.ex
@@ -1,0 +1,18 @@
+defmodule Crawley.LocalStorage do
+  @behaviour Crawley.Storage
+
+  @impl Crawley.Storage
+  def upload_repo(remote_folder_name, repo_name) do
+    zip_folder(repo_name)
+
+    File.rename(
+      "./tmp/#{repo_name}/#{repo_name}.zip",
+      "./tmp/buckets/#{remote_folder_name}/#{repo_name}.zip"
+    )
+  end
+
+  defp zip_folder(repo_name) do
+    files = File.ls!("./tmp/#{repo_name}") |> Enum.map(&String.to_charlist/1)
+    :zip.create("./tmp/#{repo_name}/#{repo_name}.zip", files)
+  end
+end

--- a/lib/crawley/local_storage.ex
+++ b/lib/crawley/local_storage.ex
@@ -3,16 +3,11 @@ defmodule Crawley.LocalStorage do
 
   @impl Crawley.Storage
   def upload_repo(remote_folder_name, repo_name) do
-    zip_folder(repo_name)
+    Crawley.Storage.zip_folder(repo_name)
 
     File.rename(
       "./tmp/#{repo_name}/#{repo_name}.zip",
       "./tmp/buckets/#{remote_folder_name}/#{repo_name}.zip"
     )
-  end
-
-  defp zip_folder(repo_name) do
-    files = File.ls!("./tmp/#{repo_name}") |> Enum.map(&String.to_charlist/1)
-    :zip.create("./tmp/#{repo_name}/#{repo_name}.zip", files)
   end
 end

--- a/lib/crawley/s3.ex
+++ b/lib/crawley/s3.ex
@@ -1,15 +1,10 @@
 defmodule Crawley.S3 do
   def upload_repo(bucket_name, repo_name) do
-    zip_folder(repo_name)
+    Crawley.Storage.zip_folder(repo_name)
 
     "./tmp/#{repo_name}/#{repo_name}.zip"
       |> ExAws.S3.Upload.stream_file
       |> ExAws.S3.upload(bucket_name, "#{repo_name}.zip")
       |> ExAws.request(region: "sa-east-1")
-  end
-
-  defp zip_folder(repo_name) do
-    files = File.ls!("./tmp/#{repo_name}") |> Enum.map(&String.to_charlist/1)
-    :zip.create("./tmp/#{repo_name}/#{repo_name}.zip", files)
   end
 end

--- a/lib/crawley/s3.ex
+++ b/lib/crawley/s3.ex
@@ -1,4 +1,7 @@
 defmodule Crawley.S3 do
+  @behaviour Crawley.Storage
+
+  @impl Crawley.Storage
   def upload_repo(bucket_name, repo_name) do
     Crawley.Storage.zip_folder(repo_name)
 

--- a/lib/crawley/storage.ex
+++ b/lib/crawley/storage.ex
@@ -1,3 +1,8 @@
 defmodule Crawley.Storage do
   @callback upload_repo(String.t, String.t) ::  {:ok, term} | {:error, term}
+
+  def zip_folder(repo_name) do
+    files = File.ls!("./tmp/#{repo_name}") |> Enum.map(&String.to_charlist/1)
+    :zip.create("./tmp/#{repo_name}/#{repo_name}.zip", files)
+  end
 end

--- a/lib/crawley/storage.ex
+++ b/lib/crawley/storage.ex
@@ -1,0 +1,3 @@
+defmodule Crawley.Storage do
+  @callback upload_repo(String.t, String.t) ::  {:ok, term} | {:error, term}
+end


### PR DESCRIPTION
Instead to upload Firebase, I used the definition that you presented and created a "mock" class,
`Crawley.LocalStorage`, to developers upload to a folder inside `./tmp`. I believe this solve the problem that we talk about related to users that can't create a free account in AWS.